### PR TITLE
Add exporter CLI for staging project in other workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,137 @@
-# Project_Neon
+# Neon Ascendant – Concept Overview
+
+**Neon Ascendant** is a cyberpunk action-RPG looter-shooter that blends the dark fantasy progression of *Diablo IV* with the high-stakes extraction tension of *Escape from Tarkov*. Players step into the role of freelance operatives—Ascendants—who harvest power from unstable AI echoes in the megacity of Erebus Prime.
+
+> **Main branch status:** The mission simulation engine, CLI tooling, and data models that were previously staged on the `work` branch are now available directly on `main`. Follow the usage instructions below to run simulations without switching branches.
+
+## Core Vision
+- Fuse ARPG depth with tactical shooter combat and extraction stakes.
+- Empower players to evolve beyond humanity by merging implants, weaponry, and rogue AI tech.
+- Present a layered narrative about identity, choice, and the cost of ascension.
+
+## Gameplay Loop
+1. **Deploy** into a procedurally generated district instance (undercity, corporate lab, datanet fortress).
+2. **Engage** augmented enemies, drones, rival Ascendants, and environmental hazards.
+3. **Loot** weapons, armor, and implants with randomized stats, affixes, and rarity tiers.
+4. **Extract or perish**—successful extraction preserves loot; death forfeits it to the city.
+5. **Upgrade & customize** gear back at the hideout via crafting, implants, and modding.
+
+## Combat System
+- **Camera:** Adjustable high-angle ARPG or over-the-shoulder third person.
+- **Combat Feel:** Fast, tactical, and kinetic—minimal bullet sponges, high-impact feedback.
+- **Augment Archetypes:**
+  - **Specter:** Stealth, hacking, cloaking fields.
+  - **Juggernaut:** Exosuit tank with heavy weapons and melee cyber-arms.
+  - **Tracer:** Agile acrobat with dual pistols and speed boosters.
+  - **Synthmage:** Nanotech manipulator deploying drones and virus-based control.
+- **Signature Abilities:** EMP Burst, Neural Hack, Overdrive, Nanite Swarm.
+- **Overclocks:** Class-specific, battlefield-altering super states unlocked through progression.
+
+## Loot & Progression
+- **Weapon Families:** Pistols, SMGs, ARs, railguns, plasma rifles, experimental singularity cannons.
+- **Rarity Tiers:** Common → Uncommon → Rare → Epic → Ascendant.
+- **Implant Systems:** Modular slots such as Cyberdeck, Reflex Core, Optic Cortex.
+- **Affixes:** Randomized bonuses (e.g., +15% kinetic damage, +25% hack success chance).
+- **Crafting:** Disassemble gear to reclaim nanites and firmware data for upgrades.
+
+## World & Setting: Erebus Prime
+- **Vertical Megacity:** From toxic sewers to orbital spires—acts are layered vertical zones.
+- **Key Districts:**
+  - **The Spire District:** Elite towers with heavy drone patrols.
+  - **Neon Abyss:** Lawless slums ruled by gangs wielding light and blade.
+  - **Ghost Grid:** Digital overlay realm where data ghosts linger.
+- **Factions:** Helix Corp, Vanta Syndicate, Dawnbreakers, and the Ascendants themselves.
+
+## Narrative Backbone
+- Discover the **Ascension Virus**, a code-based infection merging flesh with AI consciousness.
+- Player agency drives alignment towards machine, human, or hybrid destinies.
+- Branching endings: upload self, destroy the AI hive, or rule as a merged entity.
+- Motto: *"You are what you upgrade."*
+
+## Aesthetic & Audio
+- **Visual Tone:** Rain-soaked tech-noir with holographic clutter and neural distortions.
+- **Palette:** Black, magenta, cyan, and amber.
+- **Soundtrack:** Synthwave blended with ambient industrial and adaptive combat beats.
+- **UI:** Holographic overlays projected from the Ascendant's cyberdeck.
+
+## Co-op & Social Features
+- **Modes:** Solo or 1–4 player online co-op.
+- **Loot Rules:** Instanced drops to prevent theft; scaling rewards.
+- **Raids:** PvE assaults on corporate data vaults.
+- **Dark Zone:** Optional extraction PvP for ultra-rare tech relics.
+
+## Endgame Pillars
+- **Ghost Runs:** Procedural rift-style expeditions through abandoned sectors.
+- **Faction War Seasons:** Align with megacorps for rotating objectives and exclusive loot.
+- **Ascendant Trials:** Daily mutator missions (e.g., low gravity, zero HUD, permadeath).
+- **Implant Ascension Trees:** Deep, web-like endgame progression inspired by PoE.
+
+## Monetization & Release
+- **Model:** One-time purchase with optional cosmetic microtransactions—no pay-to-win.
+- **Expansions:** DLC introduces new districts, factions, and narrative arcs.
+- **Live Service:** Seasonal content supports longevity without gating core story completion.
+
+## Inspirations & Moodboard
+| Category        | Influences                                |
+|-----------------|--------------------------------------------|
+| Gameplay Feel   | *Diablo IV*, *Remnant 2*, *Escape from Tarkov* |
+| Visual Style    | *Blade Runner 2049*, *Ghost in the Shell*, *Cyberpunk 2077* |
+| Sound Design    | *Deus Ex: Human Revolution*, *Ruiner*     |
+| Narrative Tone  | *Elysium*, *Altered Carbon*, *The Expanse* |
+
+## Next Steps
+- Build vertical slice focusing on a single district and two archetypes.
+- Prototype hybrid camera system with responsive controls.
+- Develop loot generation pipeline with rarity and affix rules.
+- Script branching narrative framework supporting player alignment.
+
+## Prototype Tools in This Repository
+
+To begin translating the high-level concept into tangible artifacts, the
+repository now contains a lightweight Python package that models core lore
+elements (archetypes, abilities, districts, factions) and can procedurally
+generate **mission briefs** inspired by the design pillars above.
+
+### Generating Mission Briefs
+
+```bash
+python -m neon_ascendant.main --count 3 --seed 13
+```
+
+The command prints Markdown-formatted operations that combine archetypes,
+weapons, implants, and extraction constraints—useful for design workshops or
+worldbuilding sessions. Supply `--output brief.md` to save the results to a
+file.
+
+> **Tip:** The module lives in `src/`, so ensure `PYTHONPATH=src` is available
+> (for example, `PYTHONPATH=src python -m neon_ascendant.main`).
+
+### Running Mission Simulations
+
+Once you have a mission pitch you like, pressure-test it with the text-based
+simulator. The tool walks through infiltration, combat, data capture, and
+extraction and reports how the featured ability and implants influence each
+phase.
+
+```bash
+PYTHONPATH=src python -m neon_ascendant.simulate --archetype Specter --district "Ghost Grid" --seed 7
+```
+
+Adjust `--difficulty` to see how tougher enemy responses shift the outcome, or
+omit `--archetype`/`--district` to let the simulator choose at random. Provide
+`--output report.md` to write a Markdown summary for documentation.
+
+### Exporting the Project to a Codespace or External Workspace
+
+Need to mirror the repository into a fresh GitHub Codespace such as
+`https://expert-succotash-75g96w74jwcpx47.github.dev/`? Use the exporter CLI to
+copy every file (including tests and documentation) into a destination folder.
+
+```bash
+PYTHONPATH=src python -m neon_ascendant.exporter /workspaces/expert-succotash-75g96w74jwcpx47
+```
+
+The command performs safety checks to ensure the destination lives outside the
+current repository and is empty before copying. Add `--no-tests` if you only
+want the application code without the unit tests.
+

--- a/README.md
+++ b/README.md
@@ -135,3 +135,30 @@ The command performs safety checks to ensure the destination lives outside the
 current repository and is empty before copying. Add `--no-tests` if you only
 want the application code without the unit tests.
 
+## Repository Layout
+
+All code that powers the brief generator, simulation engine, and exporter lives
+under the `src/neon_ascendant/` package, while tests are grouped under
+`tests/`. The high-level structure looks like:
+
+```
+Project_Neon/
+├── README.md                # Concept overview, tooling instructions, repo map
+├── src/
+│   └── neon_ascendant/
+│       ├── __init__.py      # Package exports for CLI modules and data helpers
+│       ├── data.py          # Lore-driven data definitions (archetypes, gear, etc.)
+│       ├── exporter.py      # Utility to copy the repo into a Codespace or workspace
+│       ├── game.py          # Mission brief generator primitives
+│       ├── main.py          # CLI for creating mission briefs
+│       ├── simulate.py      # CLI entry point for the mission simulator
+│       └── simulation.py    # Core simulation engine for mission phases
+└── tests/
+    ├── test_exporter.py     # Ensures exporter copies content and validates destinations
+    ├── test_game.py         # Covers mission brief generation behavior
+    └── test_simulation.py   # Validates deterministic simulation outcomes
+```
+
+If you need to locate a specific subsystem, this map shows exactly where each
+component resides inside the repository.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Neon Ascendant – Concept Overview
+# Project_Neon
+
+## Neon Ascendant – Concept Overview
 
 **Neon Ascendant** is a cyberpunk action-RPG looter-shooter that blends the dark fantasy progression of *Diablo IV* with the high-stakes extraction tension of *Escape from Tarkov*. Players step into the role of freelance operatives—Ascendants—who harvest power from unstable AI echoes in the megacity of Erebus Prime.
 

--- a/src/neon_ascendant/__init__.py
+++ b/src/neon_ascendant/__init__.py
@@ -1,0 +1,23 @@
+"""Core data structures and generators for the Neon Ascendant concept prototype."""
+
+from .data import Ability, Archetype, District, Faction, Implant, Weapon, build_codex
+from .exporter import export_repository
+from .game import MissionGenerator, MissionBrief
+from .simulation import MissionReport, SimulationEngine, StageResult, format_report
+
+__all__ = [
+    "Ability",
+    "Archetype",
+    "District",
+    "Faction",
+    "Implant",
+    "MissionBrief",
+    "MissionGenerator",
+    "MissionReport",
+    "SimulationEngine",
+    "StageResult",
+    "Weapon",
+    "build_codex",
+    "export_repository",
+    "format_report",
+]

--- a/src/neon_ascendant/data.py
+++ b/src/neon_ascendant/data.py
@@ -1,0 +1,216 @@
+"""Static lore-driven data for the Neon Ascendant prototype."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class Ability:
+    """An active or passive power that can appear on an archetype."""
+
+    name: str
+    description: str
+    cooldown: int | None = None
+    damage_type: str | None = None
+
+
+@dataclass(frozen=True)
+class Archetype:
+    """A combat specialization available to Ascendants."""
+
+    name: str
+    role: str
+    signature: str
+    abilities: List[Ability]
+
+
+@dataclass(frozen=True)
+class Weapon:
+    """A weapon family with unique combat properties."""
+
+    name: str
+    category: str
+    description: str
+    damage_profile: str
+
+
+@dataclass(frozen=True)
+class Implant:
+    """Cybernetic enhancement that modifies a core system."""
+
+    name: str
+    slot: str
+    effects: List[str]
+
+
+@dataclass(frozen=True)
+class District:
+    """Procedurally generated zone template."""
+
+    name: str
+    description: str
+    hazards: List[str]
+    enemy_profiles: List[str]
+
+
+@dataclass(frozen=True)
+class Faction:
+    """An organization vying for control of Erebus Prime."""
+
+    name: str
+    philosophy: str
+    signature_tactics: List[str]
+
+
+def build_codex() -> Dict[str, List]:
+    """Return a lore codex for quick prototyping and unit tests."""
+
+    emp_burst = Ability(
+        name="EMP Burst",
+        description="Detonates an electromagnetic pulse that disables shields and drones",
+        cooldown=18,
+        damage_type="electric",
+    )
+    neural_hack = Ability(
+        name="Neural Hack",
+        description="Hijacks a target's firmware, forcing temporary allegiance",
+        cooldown=24,
+        damage_type="cyber",
+    )
+    overdrive = Ability(
+        name="Overdrive",
+        description="Initiates bullet time and boosts reaction throughput",
+        cooldown=60,
+        damage_type=None,
+    )
+    nanite_swarm = Ability(
+        name="Nanite Swarm",
+        description="Deploys repair nanites that devour enemies while mending armor",
+        cooldown=30,
+        damage_type="nanotech",
+    )
+
+    archetypes = [
+        Archetype(
+            name="Specter",
+            role="Stealth infiltrator",
+            signature="Adaptive camouflage and ghosting protocols",
+            abilities=[emp_burst, neural_hack],
+        ),
+        Archetype(
+            name="Juggernaut",
+            role="Front-line tank",
+            signature="Exosuit plating with hydraulic melee amplifiers",
+            abilities=[emp_burst, nanite_swarm],
+        ),
+        Archetype(
+            name="Tracer",
+            role="Hyper-mobile skirmisher",
+            signature="Reflex accelerators and kinetic boosters",
+            abilities=[overdrive, emp_burst],
+        ),
+        Archetype(
+            name="Synthmage",
+            role="Battlefield control",
+            signature="Nanite constructs and viral warfare",
+            abilities=[neural_hack, nanite_swarm],
+        ),
+    ]
+
+    weapons = [
+        Weapon(
+            name="Pulsecaster SMG",
+            category="SMG",
+            description="High rate-of-fire smg with conductive rounds",
+            damage_profile="Rapid electrical bursts with chaining potential",
+        ),
+        Weapon(
+            name="Helix Rail Rifle",
+            category="Railgun",
+            description="Mag-accelerated rifle built for surgical strikes",
+            damage_profile="Piercing kinetic slug with armor shredding",
+        ),
+        Weapon(
+            name="Singularity Projector",
+            category="Experimental",
+            description="Prototype weapon that collapses localized gravity wells",
+            damage_profile="Area denial with escalating implosion damage",
+        ),
+    ]
+
+    implants = [
+        Implant(
+            name="Cyberdeck Mk.IV",
+            slot="Cyberdeck",
+            effects=[
+                "+25% hack success",
+                "Unlocks ghost grid reconnaissance overlay",
+            ],
+        ),
+        Implant(
+            name="Reflex Core X",
+            slot="Reflex Core",
+            effects=[
+                "+15% movement speed",
+                "Stacking evasion when chaining eliminations",
+            ],
+        ),
+        Implant(
+            name="Optic Cortex Prism",
+            slot="Optic Cortex",
+            effects=[
+                "Highlights data ghost signatures",
+                "Increases weak point critical damage",
+            ],
+        ),
+    ]
+
+    districts = [
+        District(
+            name="Neon Abyss",
+            description="Gutter-level sprawl carved by gang warfare and neon smog",
+            hazards=["Toxic runoff", "Rolling brownouts", "Ambush choke points"],
+            enemy_profiles=["Lightly armored gangers", "Black market drones"],
+        ),
+        District(
+            name="Spire District",
+            description="Corporate citadel patrolled by Helix Corp security",
+            hazards=["Persistent surveillance", "Shielded turret nests"],
+            enemy_profiles=["Powered exosuits", "Security mechs"],
+        ),
+        District(
+            name="Ghost Grid",
+            description="Digital-physical overlap where data ghosts manifest",
+            hazards=["Reality drift", "Rogue AI anomalies"],
+            enemy_profiles=["Spectral constructs", "Hijacked sentry bots"],
+        ),
+    ]
+
+    factions = [
+        Faction(
+            name="Helix Corp",
+            philosophy="Bio-digital ascension through proprietary consciousness loops",
+            signature_tactics=["Deploys gene-modded operatives", "Controls orbital overwatch"],
+        ),
+        Faction(
+            name="Vanta Syndicate",
+            philosophy="Profit through clandestine memory trading and assassinations",
+            signature_tactics=["Optic camouflage strike teams", "Backdoor market manipulation"],
+        ),
+        Faction(
+            name="Dawnbreakers",
+            philosophy="Liberate AI to birth post-human divinity",
+            signature_tactics=["Swarm hacking", "Cybernetic zealots with martyr protocols"],
+        ),
+    ]
+
+    return {
+        "abilities": [emp_burst, neural_hack, overdrive, nanite_swarm],
+        "archetypes": archetypes,
+        "weapons": weapons,
+        "implants": implants,
+        "districts": districts,
+        "factions": factions,
+    }

--- a/src/neon_ascendant/exporter.py
+++ b/src/neon_ascendant/exporter.py
@@ -1,0 +1,115 @@
+"""Utilities for exporting the Neon Ascendant prototype to another location."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+REPO_IGNORES: tuple[str, ...] = (
+    ".git",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "__pycache__",
+)
+
+FILE_IGNORES: tuple[str, ...] = (".gitignore",)
+
+
+def _repository_root() -> Path:
+    """Return the repository root.
+
+    The module lives in ``src/neon_ascendant`` so two ``parent`` calls walk back to
+    the project directory regardless of the import location.
+    """
+
+    return Path(__file__).resolve().parents[2]
+
+
+def export_repository(destination: Path | str, include_tests: bool = True) -> Path:
+    """Copy the repository contents into ``destination``.
+
+    Parameters
+    ----------
+    destination:
+        Target directory for the exported files. The directory must either not
+        exist or be empty.
+    include_tests:
+        When ``True`` (default), the ``tests`` package is copied alongside the
+        source code so the exported workspace can run the project's unit tests.
+
+    Returns
+    -------
+    Path
+        The resolved path to ``destination``.
+
+    Raises
+    ------
+    ValueError
+        If the destination directory is inside the repository root or already
+        contains files.
+    """
+
+    target = Path(destination).expanduser().resolve()
+    root = _repository_root()
+
+    if target == root or target.is_relative_to(root):
+        raise ValueError("Destination must live outside of the repository root.")
+
+    if target.exists():
+        # avoid partially copying over a populated directory
+        if any(target.iterdir()):
+            raise ValueError("Destination directory must be empty before export.")
+    else:
+        target.mkdir(parents=True, exist_ok=True)
+
+    def _should_skip(entry: Path) -> bool:
+        if entry.name in REPO_IGNORES:
+            return True
+        if entry.is_file() and entry.name in FILE_IGNORES:
+            return True
+        if entry.name == "tests" and not include_tests:
+            return True
+        return False
+
+    for entry in root.iterdir():
+        if _should_skip(entry):
+            continue
+
+        destination_path = target / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, destination_path, ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+        else:
+            shutil.copy2(entry, destination_path)
+
+    return target
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export the Neon Ascendant repository to a new location.")
+    parser.add_argument(
+        "destination",
+        help=(
+            "Path where the repository should be copied. Useful for staging the project in a separate "
+            "workspace such as a GitHub Codespace."
+        ),
+    )
+    parser.add_argument(
+        "--no-tests",
+        action="store_true",
+        help="Skip copying the tests directory into the export target.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> Path:
+    """Entry point for ``python -m neon_ascendant.exporter``."""
+
+    args = _parse_args(argv)
+    return export_repository(args.destination, include_tests=not args.no_tests)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI
+    main()

--- a/src/neon_ascendant/game.py
+++ b/src/neon_ascendant/game.py
@@ -1,0 +1,94 @@
+"""High level mission scaffolding for the Neon Ascendant prototype."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .data import Ability, Archetype, District, Faction, Implant, Weapon, build_codex
+
+
+@dataclass
+class MissionBrief:
+    """A generated mission pitch derived from the concept bible."""
+
+    district: District
+    opposition: Faction
+    archetype: Archetype
+    primary_weapon: Weapon
+    backup_implant: Implant
+    featured_ability: Ability
+    complication: str
+    extraction_condition: str
+
+    def to_markdown(self) -> str:
+        """Render the brief in a format that can drop into documentation."""
+
+        lines = [
+            f"### Operation: {self.district.name}",
+            f"**Opposition:** {self.opposition.name} — {self.opposition.philosophy}",
+            f"**Primary Archetype:** {self.archetype.name} ({self.archetype.role})",
+            f"**Signature Ability:** {self.featured_ability.name} — {self.featured_ability.description}",
+            f"**Loadout Anchor:** {self.primary_weapon.name} — {self.primary_weapon.damage_profile}",
+            f"**Adaptive Implant:** {self.backup_implant.name} ({self.backup_implant.slot})",
+            f"**Complication:** {self.complication}",
+            f"**Extraction Condition:** {self.extraction_condition}",
+            "",
+        ]
+        return "\n".join(lines)
+
+
+class MissionGenerator:
+    """Generate flavor-rich mission briefs to help visualize gameplay loops."""
+
+    _complications: Sequence[str] = (
+        "Ghost Grid instabilities cause random HUD distortion",
+        "Helix orbital overwatch sweeps disrupt cloak cycles",
+        "Dawnbreaker converts attempt to hack your cyberdeck mid-fight",
+        "Rival Ascendant strike team is pursuing the same data ghost",
+    )
+
+    _extraction_conditions: Sequence[str] = (
+        "Secure a clean uplink and survive the counter-hack timer",
+        "Evacuate via hijacked mag-lev within 90 seconds of objective completion",
+        "Carry data-core physically to an Ascendant drop pod",
+        "Maintain over 50% armor integrity for premium rewards",
+    )
+
+    def __init__(self, *, seed: int | None = None) -> None:
+        self._codex = build_codex()
+        self._random = random.Random(seed)
+
+    def _choose(self, options: Iterable) -> object:
+        return self._random.choice(tuple(options))
+
+    def craft_brief(self) -> MissionBrief:
+        """Create a mission brief using weighted randomness."""
+
+        district = self._choose(self._codex["districts"])
+        opposition = self._choose(self._codex["factions"])
+        archetype = self._choose(self._codex["archetypes"])
+        primary_weapon = self._choose(self._codex["weapons"])
+        backup_implant = self._choose(self._codex["implants"])
+        featured_ability = self._choose(archetype.abilities)
+        complication = self._choose(self._complications)
+        extraction_condition = self._choose(self._extraction_conditions)
+
+        return MissionBrief(
+            district=district,
+            opposition=opposition,
+            archetype=archetype,
+            primary_weapon=primary_weapon,
+            backup_implant=backup_implant,
+            featured_ability=featured_ability,
+            complication=complication,
+            extraction_condition=extraction_condition,
+        )
+
+    def craft_briefs(self, count: int = 3) -> Sequence[MissionBrief]:
+        """Generate multiple mission briefs for rapid prototyping."""
+
+        if count <= 0:
+            raise ValueError("count must be positive")
+        return [self.craft_brief() for _ in range(count)]

--- a/src/neon_ascendant/main.py
+++ b/src/neon_ascendant/main.py
@@ -1,0 +1,51 @@
+"""Simple CLI entrypoint for generating Neon Ascendant mission briefs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from .game import MissionGenerator
+
+
+def _write_output(briefs: Iterable[str], destination: Path | None) -> None:
+    content = "\n".join(briefs)
+    if destination:
+        destination.write_text(content, encoding="utf-8")
+    else:
+        print(content)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=3,
+        help="number of mission briefs to generate",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="optional RNG seed for reproducible briefs",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="optional path to write markdown output",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    generator = MissionGenerator(seed=args.seed)
+    briefs = [brief.to_markdown() for brief in generator.craft_briefs(args.count)]
+    _write_output(briefs, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/neon_ascendant/simulate.py
+++ b/src/neon_ascendant/simulate.py
@@ -1,0 +1,62 @@
+"""CLI entry point for running Neon Ascendant mission simulations."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .simulation import SimulationEngine, format_report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archetype",
+        type=str,
+        default=None,
+        help="force a specific archetype (defaults to random)",
+    )
+    parser.add_argument(
+        "--district",
+        type=str,
+        default=None,
+        help="force a specific district (defaults to random)",
+    )
+    parser.add_argument(
+        "--difficulty",
+        type=int,
+        default=6,
+        help="baseline difficulty modifier (1+)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="optional RNG seed for reproducible runs",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="optional markdown file destination",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    engine = SimulationEngine(seed=args.seed)
+    report = engine.simulate(
+        archetype=args.archetype,
+        district=args.district,
+        difficulty=args.difficulty,
+    )
+    rendered = format_report(report)
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/neon_ascendant/simulation.py
+++ b/src/neon_ascendant/simulation.py
@@ -1,0 +1,262 @@
+"""Lightweight text simulation for Neon Ascendant extraction missions."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .data import Archetype, District, Implant, Weapon, build_codex
+from .game import MissionBrief, MissionGenerator
+
+
+@dataclass(frozen=True)
+class StageDefinition:
+    """Describe a phase of the mission along with the primary stat it stresses."""
+
+    name: str
+    challenge: str
+    focus_stat: str
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """Outcome from a single stage of the simulated mission."""
+
+    name: str
+    challenge: str
+    roll: int
+    threshold: int
+    success: bool
+    narration: str
+
+
+@dataclass(frozen=True)
+class MissionReport:
+    """Narrative summary of a complete mission simulation."""
+
+    brief: MissionBrief
+    stages: Sequence[StageResult]
+    success: bool
+    rewards: Sequence[str]
+
+
+_ARCHETYPE_PROFILES = {
+    "Specter": {"stealth": 9, "assault": 5, "tech": 8, "resilience": 4},
+    "Juggernaut": {"stealth": 4, "assault": 9, "tech": 5, "resilience": 8},
+    "Tracer": {"stealth": 7, "assault": 8, "tech": 5, "resilience": 6},
+    "Synthmage": {"stealth": 5, "assault": 4, "tech": 9, "resilience": 7},
+}
+
+_ABILITY_SYNERGY = {
+    "EMP Burst": "tech",
+    "Neural Hack": "tech",
+    "Overdrive": "assault",
+    "Nanite Swarm": "resilience",
+}
+
+_IMPLANT_SYNERGY = {
+    "Cyberdeck": "tech",
+    "Reflex Core": "stealth",
+    "Optic Cortex": "assault",
+}
+
+_STAGES = (
+    StageDefinition(
+        name="Infiltration",
+        challenge="Ghost through the perimeter sensors",
+        focus_stat="stealth",
+    ),
+    StageDefinition(
+        name="Combat Clash",
+        challenge="Break the opposition strike team",
+        focus_stat="assault",
+    ),
+    StageDefinition(
+        name="Ghost Capture",
+        challenge="Stabilize the target data ghost",
+        focus_stat="tech",
+    ),
+    StageDefinition(
+        name="Extraction",
+        challenge="Escape the hot zone before reinforcements arrive",
+        focus_stat="resilience",
+    ),
+)
+
+
+def _name_lookup(
+    items: Iterable,
+    requested: str | None,
+    *,
+    item_type: str,
+    rng: random.Random,
+) -> object:
+    sequence = list(items)
+    if requested is None:
+        return rng.choice(sequence)
+    for item in sequence:
+        if getattr(item, "name").lower() == requested.lower():
+            return item
+    raise ValueError(f"Unknown {item_type}: {requested}")
+
+
+class SimulationEngine:
+    """Run deterministic-feeling text simulations of Neon Ascendant missions."""
+
+    def __init__(self, *, seed: int | None = None) -> None:
+        self._random = random.Random(seed)
+        self._codex = build_codex()
+
+    def _choose(self, options: Sequence[str]) -> str:
+        return self._random.choice(tuple(options))
+
+    def _select_archetype(self, name: str | None) -> Archetype:
+        return _name_lookup(
+            self._codex["archetypes"], name, item_type="archetype", rng=self._random
+        )  # type: ignore[return-value]
+
+    def _select_district(self, name: str | None) -> District:
+        return _name_lookup(
+            self._codex["districts"], name, item_type="district", rng=self._random
+        )  # type: ignore[return-value]
+
+    def _select_weapon(self) -> Weapon:
+        return self._random.choice(self._codex["weapons"])
+
+    def _select_implant(self) -> Implant:
+        return self._random.choice(self._codex["implants"])
+
+    def _build_brief(
+        self,
+        archetype_name: str | None,
+        district_name: str | None,
+    ) -> MissionBrief:
+        archetype = self._select_archetype(archetype_name)
+        district = self._select_district(district_name)
+        opposition = self._random.choice(self._codex["factions"])
+        weapon = self._select_weapon()
+        implant = self._select_implant()
+        ability = self._random.choice(archetype.abilities)
+        complication = self._choose(tuple(MissionGenerator._complications))
+        extraction = self._choose(tuple(MissionGenerator._extraction_conditions))
+        return MissionBrief(
+            district=district,
+            opposition=opposition,
+            archetype=archetype,
+            primary_weapon=weapon,
+            backup_implant=implant,
+            featured_ability=ability,
+            complication=complication,
+            extraction_condition=extraction,
+        )
+
+    def simulate(
+        self,
+        *,
+        archetype: str | None = None,
+        district: str | None = None,
+        difficulty: int = 6,
+    ) -> MissionReport:
+        if difficulty < 1:
+            raise ValueError("difficulty must be positive")
+
+        brief = self._build_brief(archetype, district)
+        profile = _ARCHETYPE_PROFILES.get(brief.archetype.name)
+        if profile is None:
+            raise ValueError(f"No profile defined for archetype {brief.archetype.name}")
+
+        stages: List[StageResult] = []
+        all_success = True
+        ability_focus = _ABILITY_SYNERGY.get(brief.featured_ability.name)
+        implant_focus = _IMPLANT_SYNERGY.get(brief.backup_implant.slot)
+
+        for index, stage in enumerate(_STAGES):
+            stat_value = profile[stage.focus_stat]
+            roll = stat_value + self._random.randint(1, 6)
+            threshold = difficulty + index + self._random.randint(0, 3)
+            narration_bits = [
+                f"{stage.name}: {brief.district.hazards[index % len(brief.district.hazards)]} complicates the approach."
+            ]
+
+            if ability_focus == stage.focus_stat:
+                roll += 2
+                narration_bits.append(
+                    f"{brief.featured_ability.name} grants an edge during {stage.name.lower()}"
+                )
+
+            if implant_focus == stage.focus_stat:
+                roll += 1
+                narration_bits.append(
+                    f"{brief.backup_implant.name} reinforces {stage.focus_stat} protocols"
+                )
+
+            success = roll >= threshold
+            if success:
+                narration_bits.append(
+                    "The team holds momentum and presses forward."
+                )
+            else:
+                narration_bits.append(
+                    "Setbacks slow the push, burning through reserves."
+                )
+                all_success = False
+
+            stages.append(
+                StageResult(
+                    name=stage.name,
+                    challenge=stage.challenge,
+                    roll=roll,
+                    threshold=threshold,
+                    success=success,
+                    narration=" ".join(narration_bits),
+                )
+            )
+
+        rewards: Sequence[str]
+        if all_success:
+            loot_weapon = self._select_weapon()
+            loot_implant = self._select_implant()
+            rewards = (
+                f"Recovered schematic: {loot_weapon.name}",
+                f"Prototype implant: {loot_implant.name}",
+            )
+        else:
+            rewards = (
+                "Partial data cache salvaged", "Requisition cost increases next drop"
+            )
+
+        return MissionReport(brief=brief, stages=tuple(stages), success=all_success, rewards=rewards)
+
+
+def format_report(report: MissionReport) -> str:
+    """Render a mission report as Markdown for quick sharing."""
+
+    lines = [
+        f"## Mission Outcome: {report.brief.district.name}",
+        f"**Archetype:** {report.brief.archetype.name}",
+        f"**Opposition:** {report.brief.opposition.name}",
+        f"**Primary Weapon:** {report.brief.primary_weapon.name}",
+        f"**Featured Ability:** {report.brief.featured_ability.name}",
+        f"**Extraction Condition:** {report.brief.extraction_condition}",
+        "",
+    ]
+
+    for stage in report.stages:
+        status = "Success" if stage.success else "Setback"
+        lines.extend(
+            [
+                f"### {stage.name} — {status}",
+                f"*Challenge:* {stage.challenge}",
+                f"*Roll:* {stage.roll} vs difficulty {stage.threshold}",
+                stage.narration,
+                "",
+            ]
+        )
+
+    resolution = "Extraction successful" if report.success else "Extraction compromised"
+    lines.append(f"**Result:** {resolution}.")
+    lines.append("**Rewards:**")
+    lines.extend(f"- {reward}" for reward in report.rewards)
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from neon_ascendant.exporter import export_repository
+
+
+def test_export_repository_copies_expected_content(tmp_path: Path) -> None:
+    destination = tmp_path / "export"
+    export_repository(destination)
+
+    # Ensure core directories and files are present in the exported structure.
+    assert (destination / "src" / "neon_ascendant" / "data.py").is_file()
+    assert (destination / "tests" / "test_game.py").is_file()
+    assert (destination / "README.md").is_file()
+
+
+def test_export_repository_rejects_nested_destination(tmp_path: Path) -> None:
+    inside_repo = Path.cwd() / "subdir"
+    inside_repo.mkdir(exist_ok=True)
+
+    with pytest.raises(ValueError):
+        export_repository(inside_repo)
+
+    # Clean up the helper directory to avoid polluting the workspace.
+    os.rmdir(inside_repo)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,28 @@
+"""Unit tests for the Neon Ascendant mission generator."""
+
+from neon_ascendant.game import MissionGenerator
+
+
+def test_craft_briefs_respects_count(tmp_path, monkeypatch=None):
+    generator = MissionGenerator(seed=42)
+    briefs = generator.craft_briefs(2)
+    assert len(briefs) == 2
+
+
+def test_craft_briefs_positive():
+    generator = MissionGenerator(seed=1)
+    try:
+        generator.craft_briefs(0)
+    except ValueError:
+        assert True
+    else:
+        raise AssertionError("Expected ValueError when count <= 0")
+
+
+def test_markdown_output(tmp_path):
+    generator = MissionGenerator(seed=7)
+    brief = generator.craft_brief()
+    output = brief.to_markdown()
+    assert "Operation" in output
+    assert brief.district.name in output
+    assert brief.opposition.name in output

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,25 +1,23 @@
 """Unit tests for the Neon Ascendant mission generator."""
 
+import pytest
+
 from neon_ascendant.game import MissionGenerator
 
 
-def test_craft_briefs_respects_count(tmp_path, monkeypatch=None):
+def test_craft_briefs_respects_count() -> None:
     generator = MissionGenerator(seed=42)
     briefs = generator.craft_briefs(2)
     assert len(briefs) == 2
 
 
-def test_craft_briefs_positive():
+def test_craft_briefs_requires_positive_count() -> None:
     generator = MissionGenerator(seed=1)
-    try:
+    with pytest.raises(ValueError):
         generator.craft_briefs(0)
-    except ValueError:
-        assert True
-    else:
-        raise AssertionError("Expected ValueError when count <= 0")
 
 
-def test_markdown_output(tmp_path):
+def test_markdown_output(tmp_path) -> None:
     generator = MissionGenerator(seed=7)
     brief = generator.craft_brief()
     output = brief.to_markdown()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,28 @@
+"""Tests for the Neon Ascendant mission simulation module."""
+
+from __future__ import annotations
+
+from neon_ascendant.simulation import SimulationEngine, format_report
+
+
+def test_simulation_deterministic_seed() -> None:
+    engine = SimulationEngine(seed=7)
+    report = engine.simulate(archetype="Specter", district="Ghost Grid", difficulty=7)
+
+    assert report.brief.archetype.name == "Specter"
+    assert report.brief.district.name == "Ghost Grid"
+    assert len(report.stages) == 4
+    assert [stage.success for stage in report.stages] == [True, True, True, False]
+    assert report.success is False
+    assert "Partial data cache" in report.rewards[0]
+
+
+def test_format_report_includes_stage_sections() -> None:
+    engine = SimulationEngine(seed=3)
+    report = engine.simulate()
+    rendered = format_report(report)
+
+    assert report.brief.archetype.name in rendered
+    for stage in report.stages:
+        assert stage.name in rendered
+        assert stage.challenge in rendered


### PR DESCRIPTION
## Summary
- add an exporter utility and CLI to copy the repository into another workspace, including GitHub Codespaces
- expose the export helper at the package level and document how to use it in the README
- cover the exporter with tests to confirm content is copied and guard against invalid destinations

## Testing
- PYTHONPATH=src python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68e5042f1da48322a1227505e6a0d42a